### PR TITLE
feat: add helm chart for signalen-frontend-wcag

### DIFF
--- a/charts/signalen-frontend-wcag/.helmignore
+++ b/charts/signalen-frontend-wcag/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/signalen-frontend-wcag/Chart.yaml
+++ b/charts/signalen-frontend-wcag/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: signalen-frontend-wcag
+description: Improved accessible (WCAG) frontend for Signalen 1.0
+
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/charts/signalen-frontend-wcag/templates/_helpers.tpl
+++ b/charts/signalen-frontend-wcag/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "signalen-frontend-wcag.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "signalen-frontend-wcag.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "signalen-frontend-wcag.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "signalen-frontend-wcag.labels" -}}
+helm.sh/chart: {{ include "signalen-frontend-wcag.chart" . }}
+{{ include "signalen-frontend-wcag.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "signalen-frontend-wcag.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "signalen-frontend-wcag.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "signalen-frontend-wcag.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "signalen-frontend-wcag.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/signalen-frontend-wcag/templates/configmap.yaml
+++ b/charts/signalen-frontend-wcag/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "signalen-frontend-wcag.fullname" . }}
+  labels:
+    {{- include "signalen-frontend-wcag.labels" . | nindent 4 }}
+data:
+  config.json: |-
+{{ .Values.config | toJson | indent 4 }}
+  customDesignTokens.json: |-
+{{ .Values.customDesignTokens | toJson | indent 4 }}

--- a/charts/signalen-frontend-wcag/templates/deployment.yaml
+++ b/charts/signalen-frontend-wcag/templates/deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "signalen-frontend-wcag.fullname" . }}
+  labels:
+    {{- include "signalen-frontend-wcag.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "signalen-frontend-wcag.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ .Values.config | toJson | sha256sum }}
+        checksum/customDesignTokens: {{ .Values.customDesignTokens | toJson | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "signalen-frontend-wcag.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "signalen-frontend-wcag.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/config.json
+              subPath: config.json
+            - name: config
+              mountPath: /app/design-tokens/organizations/custom.json
+              subPath: customDesignTokens.json
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "signalen-frontend-wcag.fullname" . }}
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/signalen-frontend-wcag/templates/hpa.yaml
+++ b/charts/signalen-frontend-wcag/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "signalen-frontend-wcag.fullname" . }}
+  labels:
+    {{- include "signalen-frontend-wcag.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "signalen-frontend-wcag.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/signalen-frontend-wcag/templates/ingress.yaml
+++ b/charts/signalen-frontend-wcag/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "signalen-frontend-wcag.fullname" . }}
+  labels:
+    {{- include "signalen-frontend-wcag.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "signalen-frontend-wcag.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/signalen-frontend-wcag/templates/service.yaml
+++ b/charts/signalen-frontend-wcag/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "signalen-frontend-wcag.fullname" . }}
+  labels:
+    {{- include "signalen-frontend-wcag.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "signalen-frontend-wcag.selectorLabels" . | nindent 4 }}

--- a/charts/signalen-frontend-wcag/templates/serviceaccount.yaml
+++ b/charts/signalen-frontend-wcag/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "signalen-frontend-wcag.serviceAccountName" . }}
+  labels:
+    {{- include "signalen-frontend-wcag.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/signalen-frontend-wcag/values.yaml
+++ b/charts/signalen-frontend-wcag/values.yaml
@@ -1,0 +1,176 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/delta10/signalen-frontend-wcag
+  pullPolicy: IfNotPresent
+  tag: main
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+config:
+  baseUrlApi: https://api.meldingen.demo.meierijstad.delta10.cloud/1
+  pdokUrlApi: https://api.pdok.nl/bzk/locatieserver/
+  frontendUrl: https://signalen.demo.meierijstad.delta10.cloud
+  maptilerApiKey: x0IfDO01xuLQQKYlSzuz
+  maptilerMap: https://api.maptiler.com/maps/nl-cartiqo-topo
+  maptilerMapDarkMode: https://api.maptiler.com/maps/streets-v2-dark
+  restrictSelectionArea: false
+  base:
+    theme: custom
+    municipality: meierijstad
+    municipality_display_name: Purmerend
+    assets_url: https://meldingen.demo.meierijstad.delta10.cloud
+    supportedLanguages:
+    - label: Schakel over naar het Nederlands
+      lang: nl
+      name: Nederlands
+    naam: gemeente Purmerend
+    header:
+      logo:
+        alt: Gemeente Purmerend logo, naar de homepagina
+        url: purmerend-logo-design-tokens.svg
+        caption: Purmerend
+    contact:
+      tel: '0299 452 452'
+    map:
+      find_address_in_distance: 30
+      minimal_zoom: 17
+      center:
+      - 51.52
+      - 5.112
+      maxBounds:
+      - - 3.31497114423
+        - 50.803721015
+      - - 7.09205325687
+        - 53.5104033474
+      default_zoom: 12
+    links:
+      about: https://signalen.org
+      accessibility: https://signalen.org
+      help: https://signalen.org/
+      home: https://purmerend.nl/
+      privacy: https://vng.nl/privacyverklaring-vereniging-van-nederlandse-gemeenten
+    i18n:
+      nl:
+        describe_report:
+          alert:
+            help_text: Problemen met het indienen van een melding? Bel [0299452452](tel:+0299452452)
+              of mail naar [meldingen@purmerend.nl](mailto:meldingen@purmerend.nl).
+              Wij zijn bereikbaar van maandag tot en met vrijdag van 8:00 uur tot 18:00
+              uur.
+      en:
+        describe_report:
+          alert:
+            help_text: Having trouble submitting a report? Call [0299452452](tel:+0299452452)
+              or mail [meldingen@purmerend.nl](mailto:meldingen@purmerend.nl). We are
+              available monday through friday from 8:00 AM to 6:00 PM.
+
+# These are mounted in /app/design-tokens/organizations/custom.json
+customDesignTokens: {}
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 3000
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This adds a Helm chart for signalen-frontend-wcag and supersedes signalen-frontend